### PR TITLE
Prepare 0.2 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rutie-serde"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Andrii Dmytrenko <andrii.dmytrenko@deliveroo.co.uk>"]
 edition = "2018"
 description = "rutie serde integration"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ categories = ["external-ffi-bindings"]
 license = "MIT"
 
 [dependencies]
-rutie = "0.7"
-serde = "1.0"
-serde_json = "1.0"
-log = "^0.4"
+log = "0.4.13"
+rutie = "0.8.1"
+serde = "1.0.119"

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ crate-type = ["dylib"]
 name = "ruby_rust_demo"
 
 [dependencies]
-rutie = "^0.5.2"
-rutie-serde = "^0.1.0"
+rutie = "0.8"
+rutie-serde = "0.2"
 serde = "1.0"
 serde_derive = "1.0"
 ```
@@ -24,11 +24,11 @@ This macro takes care of deserializing arguments and serializing return values.
 It also captures all panics inside those methods and raises them as an exception in ruby.
 
 ```rust
-use rutie::{Class, Object, class};
-use rutie_serde::rutie_serde_methods;
-use serde_derive::{Serialize, Deserialize};
+use rutie::{class, Class, Object};
+use rutie_serde::{ruby_class, rutie_serde_methods};
+use serde_derive::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct User {
     pub name: String,
     pub id: u64,
@@ -39,22 +39,19 @@ rutie_serde_methods!(
     HelloWorld,
     _itself,
     ruby_class!(Exception),
-
     fn hello(name: String) -> String {
         format!("Hello {}", name)
     }
-
     fn hello_user(user: User) -> String {
         format!("Hello {:?}", user)
     }
 );
 
-
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C" fn Init_ruby_rust_demo() {
     let mut class = Class::new("RubyRustDemo", None);
-    class.define(|itself| itself.def_self("hello", hello) );
-    class.define(|itself| itself.def_self("hello_user", hello_user) );
+    class.define(|itself| itself.def_self("hello", hello));
+    class.define(|itself| itself.def_self("hello_user", hello_user));
 }
 ```

--- a/src/de.rs
+++ b/src/de.rs
@@ -369,7 +369,7 @@ impl<'de, 'a> de::Deserializer<'de> for Deserializer {
             "deserialize_enum name: {:?}, variants: {:?}",
             name, variants
         );
-        visitor.visit_enum(EnumAccess::new(self.object.clone()))
+        visitor.visit_enum(EnumAccess::new(self.object))
     }
 
     fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value>

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,6 +1,6 @@
+use log::debug;
 use rutie::{AnyObject, Array, Boolean, Class, Fixnum, Float, NilClass, Object, RString};
 use serde::de::{self, Deserialize, DeserializeSeed, MapAccess, Visitor};
-use log::debug;
 
 use crate::{Error, ErrorKind, Result, ResultExt};
 
@@ -344,10 +344,7 @@ impl<'de, 'a> de::Deserializer<'de> for Deserializer {
         debug!("deserialize_struct: {}, fields: {:?}", name, fields);
         if self
             .object
-            .protect_send(
-                "is_a?",
-                &[Class::from_existing("Hash").to_any_object()],
-            )?
+            .protect_send("is_a?", &[Class::from_existing("Hash").to_any_object()])?
             .try_convert_to::<Boolean>()?
             .to_bool()
         {

--- a/src/error.rs
+++ b/src/error.rs
@@ -149,8 +149,8 @@ impl IntoException for Error {
             }
             _ => {
                 let msg = format!("{}", self);
-                let obj = default_class
-                    .new_instance(&[rutie::RString::new_utf8(&msg).to_any_object()]);
+                let obj =
+                    default_class.new_instance(&[rutie::RString::new_utf8(&msg).to_any_object()]);
                 rutie::AnyException::from(obj.value())
             }
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,6 @@
 use std::fmt;
 
 use rutie::{self, Exception, Object};
-use serde;
 
 pub enum ErrorKind {
     Message(String),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,10 +80,8 @@ pub mod anyobject_serde {
         D: Deserializer<'de>,
     {
         let object_id = usize::deserialize(deserializer)?;
-        let object = Class::from_existing("ObjectSpace").protect_public_send(
-            "_id2ref",
-            &[Fixnum::new(object_id as i64).to_any_object()],
-        );
+        let object = Class::from_existing("ObjectSpace")
+            .protect_public_send("_id2ref", &[Fixnum::new(object_id as i64).to_any_object()]);
         object.map_err(|_e| D::Error::missing_field("_id2ref raised an error"))
     }
 }

--- a/src/panics.rs
+++ b/src/panics.rs
@@ -25,8 +25,7 @@ where
                 Some(message) => message,
                 None => "Unknown error".to_owned(),
             });
-            let instance =
-                exception_class.new_instance(&[RString::new_utf8(&msg).to_any_object()]);
+            let instance = exception_class.new_instance(&[RString::new_utf8(&msg).to_any_object()]);
             let exception = rutie::AnyException::from(instance.value());
             VM::raise_ex(exception);
             unreachable!("VM::raise_ex");

--- a/src/panics.rs
+++ b/src/panics.rs
@@ -1,4 +1,3 @@
-use std;
 use std::cell::RefCell;
 use std::panic::UnwindSafe;
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,4 +1,4 @@
-use rutie::{self, AnyObject, Object, Encoding};
+use rutie::{self, AnyObject, Encoding, Object};
 use serde::ser::{self, Serialize};
 
 use crate::{Error, Result};


### PR DESCRIPTION
Just some minor cleanups before we release a new version:

- rust clippy and rustfmt
- update to rutie 0.8
- bump dependencies
- remove unused `serde_json` dependency
- bump the version in the cargo manifest