### PR TITLE
Deserialize fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rutie-serde"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Andrii Dmytrenko <andrii.dmytrenko@deliveroo.co.uk>"]
 edition = "2018"
 description = "rutie serde integration"

--- a/src/de.rs
+++ b/src/de.rs
@@ -100,7 +100,7 @@ impl<'de, 'a> de::Deserializer<'de> for Deserializer {
             "Float" => self.deserialize_f64(visitor),
             "Hash" => self.deserialize_map(visitor),
             "NilClass" => visitor.visit_none(),
-            "String" => self.deserialize_string(visitor),
+            "String" | "Symbol" => self.deserialize_string(visitor),
             "TrueClass" | "FalseClass" => self.deserialize_bool(visitor),
             _ => Err(format!("No rules to deserialize {}", class_name).into()),
         }

--- a/src/de.rs
+++ b/src/de.rs
@@ -240,8 +240,8 @@ impl<'de, 'a> de::Deserializer<'de> for Deserializer {
         V: Visitor<'de>,
     {
         debug!("deserialize_bytes: {:?}", self.object);
-        let s = try_convert_to!(self.object, RString)?.to_string_unchecked();
-        visitor.visit_bytes(&s.into_bytes())
+        let s = try_convert_to!(self.object, RString)?;
+        visitor.visit_bytes(s.to_bytes_unchecked())
     }
 
     fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value>
@@ -249,8 +249,8 @@ impl<'de, 'a> de::Deserializer<'de> for Deserializer {
         V: Visitor<'de>,
     {
         debug!("deserialize_byte_buf: {:?}", self.object);
-        let s = try_convert_to!(self.object, RString)?.to_string_unchecked();
-        visitor.visit_byte_buf(s.into_bytes())
+        let s = try_convert_to!(self.object, RString)?;
+        visitor.visit_byte_buf(s.to_vec_u8_unchecked())
     }
 
     fn deserialize_option<V>(self, visitor: V) -> Result<V::Value>


### PR DESCRIPTION
- Updates `deserialize_any` to support `Symbol`
- Updates `deserialize_bytes` and `deserialize_bytes_buf` to convert the object to a bytes slice/buffer directly
- Updates `deserialize_str` and `deserialize_string` to convert the object to a bytes slice/buffer and either convert it to a `str`/`String` if it contains valid UTF-8, or pass it as-is to the `Visitor` otherwise
- Bumps the version of the crate